### PR TITLE
Add a config_file argument to optoforce_node.launch.

### DIFF
--- a/launch/optoforce_node.launch
+++ b/launch/optoforce_node.launch
@@ -1,9 +1,12 @@
 <launch>
+
+	<!-- Configuration file with parameters for optoforce_node -->
+	<arg name="config_file" default="$(find optoforce_ros)/cfg/acquisition_params.yaml"/>
+
     <!-- OptoForce Acquisition parameters -->
-    <rosparam file="$(find optoforce_ros)/cfg/acquisition_params.yaml" command="load" ns="optoforce_node"/>
+    <rosparam file="$(arg config_file)" command="load" ns="optoforce_node"/>
 
     <!-- OptoForce Acquisition node -->
-    <node pkg="optoforce_ros" type="optoforce_node" name="optoforce_node" output="screen" cwd="node">
-    </node>
+    <node pkg="optoforce_ros" type="optoforce_node" name="optoforce_node" output="screen" cwd="node"/>
 
 </launch>


### PR DESCRIPTION
Allows to launch the node with project specific configuration files without the
need to modify the sample configuration file in the package.

I would even go further and remove the acquisition_params.yaml file, which is specific to an individual device (contains serial number, calibration info, etc.) and provide an updated description of what this file should contain in the README.