### PR TITLE
Require C++0X/C++11 support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,18 @@ include_directories(${catkin_INCLUDE_DIRS})
 ## System dependencies are found with CMake's conventions
 find_package( Boost REQUIRED COMPONENTS system chrono)
 
+## Check c++11 / c++0x
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "-std=c++11")
+elseif(COMPILER_SUPPORTS_CXX0X)
+    set(CMAKE_CXX_FLAGS "-std=c++0x")
+else()
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+endif()
+
 add_action_files(
   DIRECTORY action
   FILES OptoForce.action


### PR DESCRIPTION
Building with clang requires C++0X/C++11 support to be explicitly enabled.

Found out by chance, and not sure why g++ does not require it, but I figure it
doesn't harm to explicitly require this.